### PR TITLE
Fixed readme and default translations for severe pollen levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For each pollen type and location, the integration creates two sensors:
 - `none` - Pollen type not forecast for that day
 - `low` - Low pollen level
 - `moderate` - Moderate pollen level
-- `high` - High pollen level
+- `severe` - Severe pollen level
 - `extreme` - Extreme pollen level
 > ℹ️ The integration was set up before anything was highly in bloom - these values need to be verified as the season progresses.  
 
@@ -90,7 +90,7 @@ automation:
     trigger:
       - platform: state
         entity_id: sensor.pollen_birch_molde_today
-        to: "high"
+        to: "severe"
       - platform: state
         entity_id: sensor.pollen_birch_molde_today
         to: "extreme"

--- a/custom_components/pollenvarsel_naaf_yr/locale/en.json
+++ b/custom_components/pollenvarsel_naaf_yr/locale/en.json
@@ -8,7 +8,7 @@
     "none": "Not forecast",
     "low": "Low",
     "moderate": "Moderate",
-    "high": "High",
+    "severe": "Severe",
     "extreme": "Extreme"
   },
   "entry": {

--- a/custom_components/pollenvarsel_naaf_yr/locale/nb.json
+++ b/custom_components/pollenvarsel_naaf_yr/locale/nb.json
@@ -8,7 +8,7 @@
     "none": "Ingen",
     "low": "Beskjeden",
     "moderate": "Moderat",
-    "high": "Høy",
+    "severe": "Kraftig",
     "extreme": "Ekstrem"
   },
   "entry": {

--- a/custom_components/pollenvarsel_naaf_yr/locale/nn.json
+++ b/custom_components/pollenvarsel_naaf_yr/locale/nn.json
@@ -8,7 +8,7 @@
     "none": "Ingen",
     "low": "Beskjeden",
     "moderate": "Moderat",
-    "high": "Høg",
+    "severe": "Kraftig",
     "extreme": "Ekstrem"
   },
   "entry": {


### PR DESCRIPTION
Corrected the key name for severe pollen levels in readme , and updated the default translations for that level string. 